### PR TITLE
update filter related stuff

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -371,7 +371,7 @@ Priorities:
 
 1. Wedding Organizer requests to filter contacts by specific tag(s).
 2. Bridal Boss prompts for the tag(s) to filter by.
-3. Wedding Organizer enters the desired tag(s) (e.g., "Florist", "Wedding A").
+3. Wedding Organizer enters the desired tag(s), prefixed with t/ (e.g., "t/Florist", "t/Wedding A").
 4. Bridal Boss displays a list of contacts that match the specified tag(s).
 
    Use case ends.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -167,18 +167,14 @@ Format: `clear`
 
 Filters all persons whose tags contain any of the specified keywords. The filtering is case-insensitive.
 
-Format: `filter KEYWORD [MORE_KEYWORDS]...`
+Format: `filter t/KEYWORD t/[MORE_KEYWORDS]...`
 
 * Filters all persons whose tags contain any of the specified keywords.
-* The search is case-insensitive. e.g `friend` will match `Friend`
-* The order of the keywords does not matter. e.g. `friend colleague` will match `colleague friend`
-* Only full words will be matched e.g. `col` will not match `colleague`
+* The search is case-insensitive. e.g `t/friend` will match `t/Friend`
+* The order of the keywords does not matter. e.g. `t/friend t/colleague` will match `t/colleague t/friend`
+* Only full words will be matched e.g. `t/col` will not match `t/colleague`
 
-Example: `filter friends family` Lists all persons in the address book whose tags match any of the specified keywords.
-
-**Change Highlight**:
-- Added the **filter** command to the list of available commands.
-- Detailed usage and example of the **filter** command added.
+Example: `filter t/friends t/family` Lists all persons in the address book whose tags match any of the specified keywords.
 
 ### Exiting the program : `exit`
 
@@ -230,6 +226,7 @@ Action     | Format, Examples
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
+**Filter** | `filter t/KEYWORD t/[MORE_KEYWORDS]...`<br> e.g., `filter t/friends
 **View**   | `view KEYWORD`<br> e.g., `view Alex`, `view Alex Tan`
 **List**   | `list`
 **Help**   | `help`

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -17,8 +17,8 @@ public class FilterCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all persons whose tags contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " friends family";
+            + "Parameters: t/TAG [t/TAG]...\n"
+            + "Example: " + COMMAND_WORD + " t/friends t/family";
 
     private final TagContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -12,6 +12,9 @@ import seedu.address.model.person.TagContainsKeywordsPredicate;
  * Parses input arguments and creates a new FilterCommand object
  */
 public class FilterCommandParser implements Parser<FilterCommand> {
+
+    private static final Prefix TAG_PREFIX = CliSyntax.PREFIX_TAG;
+
     /**
      * Parses the given {@code String} of arguments in the context of the FilterCommand
      * and returns a FilterCommand object for execution.
@@ -24,7 +27,16 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
-        String[] tagKeywords = trimmedArgs.split("\\s+");
+        // Extract the string value from the Prefix object
+        String[] tagKeywords = Arrays.stream(trimmedArgs.split("\\s+"))
+                .filter(arg -> arg.startsWith(TAG_PREFIX.getPrefix()))
+                .map(arg -> arg.substring(TAG_PREFIX.getPrefix().length()))
+                .toArray(String[]::new);
+
+        if (tagKeywords.length == 0) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
 
         return new FilterCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
     }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -27,13 +27,13 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
-        // Extract the string value from the Prefix object
         String[] tagKeywords = Arrays.stream(trimmedArgs.split("\\s+"))
                 .filter(arg -> arg.startsWith(TAG_PREFIX.getPrefix()))
                 .map(arg -> arg.substring(TAG_PREFIX.getPrefix().length()))
                 .toArray(String[]::new);
 
-        if (tagKeywords.length == 0) {
+        // Check if keywords are empty
+        if (tagKeywords.length == 0 || Arrays.stream(tagKeywords).anyMatch(String::isEmpty)) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -1,46 +1,54 @@
 {
   "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
-  "persons" : [ {
-    "name" : "Alice Pauline",
-    "phone" : "94351253",
-    "email" : "alice@example.com",
-    "address" : "123, Jurong West Ave 6, #08-111",
-    "tags" : [ "friends" ]
-  }, {
-    "name" : "Benson Meier",
-    "phone" : "98765432",
-    "email" : "johnd@example.com",
-    "address" : "311, Clementi Ave 2, #02-25",
-    "tags" : [ "owesMoney", "friends" ]
-  }, {
-    "name" : "Carl Kurz",
-    "phone" : "95352563",
-    "email" : "heinz@example.com",
-    "address" : "wall street",
-    "tags" : [ ]
-  }, {
-    "name" : "Daniel Meier",
-    "phone" : "87652533",
-    "email" : "cornelia@example.com",
-    "address" : "10th street",
-    "tags" : [ "friends" ]
-  }, {
-    "name" : "Elle Meyer",
-    "phone" : "94822244",
-    "email" : "werner@example.com",
-    "address" : "michegan ave",
-    "tags" : [ ]
-  }, {
-    "name" : "Fiona Kunz",
-    "phone" : "94824277",
-    "email" : "lydia@example.com",
-    "address" : "little tokyo",
-    "tags" : [ ]
-  }, {
-    "name" : "George Best",
-    "phone" : "94824422",
-    "email" : "anna@example.com",
-    "address" : "4th street",
-    "tags" : [ ]
-  } ]
+  "persons": [
+    {
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tags": ["friends", "gym"]
+    },
+    {
+      "name": "Benson Meier",
+      "phone": "98765432",
+      "email": "johnd@example.com",
+      "address": "311, Clementi Ave 2, #02-25",
+      "tags": ["owesMoney", "friends"]
+    },
+    {
+      "name": "Carl Kurz",
+      "phone": "95352563",
+      "email": "heinz@example.com",
+      "address": "wall street",
+      "tags": ["colleague"]
+    },
+    {
+      "name": "Daniel Meier",
+      "phone": "87652533",
+      "email": "cornelia@example.com",
+      "address": "10th street",
+      "tags": ["friends", "colleague"]
+    },
+    {
+      "name": "Elle Meyer",
+      "phone": "94822244",
+      "email": "werner@example.com",
+      "address": "michegan ave",
+      "tags": []
+    },
+    {
+      "name": "Fiona Kunz",
+      "phone": "94824277",
+      "email": "lydia@example.com",
+      "address": "little tokyo",
+      "tags": ["gym"]
+    },
+    {
+      "name": "George Best",
+      "phone": "94824422",
+      "email": "anna@example.com",
+      "address": "4th street",
+      "tags": []
+    }
+  ]
 }

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -55,7 +55,7 @@ public class FilterCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        TagContainsKeywordsPredicate predicate = preparePredicate(" ");
+        TagContainsKeywordsPredicate predicate = preparePredicate("t/ ");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -64,18 +64,19 @@ public class FilterCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        TagContainsKeywordsPredicate predicate = preparePredicate("friends family gym");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 5);
+        TagContainsKeywordsPredicate predicate = preparePredicate("friends gym colleague");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(3, model.getFilteredPersonList().size());
+        assertEquals(5, model.getFilteredPersonList().size());
     }
 
     /**
      * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
      */
     private TagContainsKeywordsPredicate preparePredicate(String userInput) {
+        System.out.println(Arrays.asList(userInput.split("\\s+")));
         return new TagContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -22,6 +22,18 @@ public class FilterCommandParserTest {
     }
 
     @Test
+    public void parse_missingTagPrefix_throwsParseException() {
+        assertParseFailure(parser, "friends family", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_justPrefix_throwsParseException() {
+        assertParseFailure(parser, "t/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_validArgs_returnsFilterCommand() {
         // no leading and trailing whitespaces
         FilterCommand expectedFilterCommand =

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -26,9 +26,9 @@ public class FilterCommandParserTest {
         // no leading and trailing whitespaces
         FilterCommand expectedFilterCommand =
                 new FilterCommand(new TagContainsKeywordsPredicate(Arrays.asList("friends", "family")));
-        assertParseSuccess(parser, "friends family", expectedFilterCommand);
+        assertParseSuccess(parser, "t/friends t/family", expectedFilterCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n friends \n \t family  \t", expectedFilterCommand);
+        assertParseSuccess(parser, " \n t/friends \n \t t/family  \t", expectedFilterCommand);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,21 +26,30 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
-            .withTags("friends").build();
+            .withTags("friends", "gym").build();
+
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
+
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withAddress("wall street")
+            .withTags("colleague").build();
+
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street")
+            .withTags("friends", "colleague").build();
+
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("94822244")
             .withEmail("werner@example.com").withAddress("michegan ave").build();
+
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("94824277")
-            .withEmail("lydia@example.com").withAddress("little tokyo").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo").withTags("gym").build();
+
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("94824422")
             .withEmail("anna@example.com").withAddress("4th street").build();
+
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("84824244")


### PR DESCRIPTION
- Updated `TypicalPersons` class to ensure tag consistency between in-memory 
objects and `TypicalPersonsAddressBook.json`.
  - Added missing tags in `TypicalPersonsAddressBook.json`:
    - Added "gym" tag to Alice Pauline.
    - Added "colleague" tag to Carl Kurz and Daniel Meier.
    - Added "gym" tag to Fiona Kunz.

- Fixed failing `FilterCommandTest`:
  - Adjusted test case in `execute_multipleKeywords_multiplePersonsFound()` to reflect 
  updated tag data in typical persons.
  - Modified expected message to match the updated count of persons with tags in 
  the filter test.

- Fixed failing `JsonSerializableAddressBookTest`:
  - Ensured the typical persons data in the JSON file matches the expected data in 
  the `TypicalPersons` class for successful comparison.

- Filter is now done using `filter t/[TAG]` from `filter [KEYWORD]`.