### PR TITLE
Edit delete command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -138,10 +138,12 @@ View the contact of a specified person from the address book.
 Format: `view KEYWORD`
 
 * This command is case-insensitive. e.g `alex tan` will match `Alex Tan`
-* The keyword can be either the full name (consisting multiple words) or partial name (consisting of only one word).
-* Viewing the full name will match the exact name given e.g. `Alex Tan` will only give `Alex Tan`
-* Viewing partial name will find all contacts that has names containing the keyword e.g. `Alex` will give `Alex Tan` and `Alex Yeo`
+* The keyword can be either the full name or partial name (consisting of only one word).
 * Only the name can be used for viewing
+
+Examples:
+* `view John` returns `john` and `John Doe`
+* `view Alex Yeo` return `Alex Yeo` and `Alex Yeo Jun Jie`
 
 ### Deleting a person : `delete`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -147,6 +147,8 @@ Format: `view KEYWORD`
 
 Deletes the specified person from the address book.
 
+If you know the index of the specific contact you want to delete:
+
 Format: `delete INDEX`
 
 * Deletes the person at the specified `INDEX`.
@@ -155,7 +157,21 @@ Format: `delete INDEX`
 
 Examples:
 * `list` followed by `delete 2` deletes the 2nd person in the address book.
-* `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
+
+If you do not know the index but know the name of the contact you want to delete:
+
+Format: `delete KEYWORD`
+
+* This command is case-insensitive. e.g. `alex tan` will match `Alex Tan`
+* The keyword can be either the full name or partial name.
+* When there are more than one contact, of which name contains the keyword, a filtered list containing those contacts 
+  will be given. From that list, you can obtain the index of the specific contact you want to delete. With that index, 
+  you can do a `delete INDEX` to delete that specific contact.
+
+Example:
+
+* `delete Betsy` will delete the contact of Betsy Tan directly if there are no duplicates.
+* `delete Alex` will give a list of contacts named `Alex`, and user can choose which contact from filtered list to deleted from.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,6 +12,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NameMatchesNamePredicate;
 import seedu.address.model.person.Person;
 
 /**
@@ -75,11 +77,12 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return personToDelete;
     }
 
     public Person deleteWithKeyword(Model model) throws CommandException {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+        NameMatchesNamePredicate predicate = new NameMatchesNamePredicate(
                 Arrays.asList(this.targetKeyword));
         model.updateFilteredPersonList(predicate);
         List<Person> filteredList = model.getFilteredPersonList();
@@ -89,6 +92,7 @@ public class DeleteCommand extends Command {
         } else if (filteredList.size() == 1) {
             Person personToDelete = filteredList.get(0);
             model.deletePerson(personToDelete);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
             return personToDelete;
         } else {
             return null;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -11,7 +11,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameMatchesNamePredicate;
+import seedu.address.model.person.NameMatchesKeywordPredicate;
 import seedu.address.model.person.Person;
 
 /**
@@ -34,14 +34,14 @@ public class DeleteCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     private final Index targetIndex;
-    private final String targetKeyword;
+    private final NameMatchesKeywordPredicate predicate;
 
     /**
      * Creates a Delete Command to delete the specified contact
      */
-    public DeleteCommand(Index targetIndex, String targetKeyword) {
+    public DeleteCommand(Index targetIndex, NameMatchesKeywordPredicate predicate) {
         this.targetIndex = targetIndex;
-        this.targetKeyword = targetKeyword;
+        this.predicate = predicate;
     }
 
     @Override
@@ -95,8 +95,7 @@ public class DeleteCommand extends Command {
      * @throws CommandException if the list filtered using {@code targetKeyword} is empty
      */
     public Person deleteWithKeyword(Model model) throws CommandException {
-        NameMatchesNamePredicate predicate = new NameMatchesNamePredicate(
-                Arrays.asList(this.targetKeyword));
+
         model.updateFilteredPersonList(predicate);
         List<Person> filteredList = model.getFilteredPersonList();
 
@@ -126,18 +125,18 @@ public class DeleteCommand extends Command {
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
 
         if (targetIndex == null && otherDeleteCommand.targetIndex == null
-                && targetKeyword == null && otherDeleteCommand.targetKeyword == null) {
+                && predicate == null && otherDeleteCommand.predicate == null) {
             return true;
         }
 
         if (targetIndex != null && otherDeleteCommand.targetIndex != null
-                && targetKeyword == null && otherDeleteCommand.targetKeyword == null) {
+                && predicate == null && otherDeleteCommand.predicate == null) {
             return targetIndex.equals(otherDeleteCommand.targetIndex);
         }
 
         if (targetIndex == null && otherDeleteCommand.targetIndex == null
-                && targetKeyword != null && otherDeleteCommand.targetKeyword != null) {
-            return targetKeyword.equals(otherDeleteCommand.targetKeyword);
+                && predicate != null && otherDeleteCommand.predicate != null) {
+            return predicate.equals(otherDeleteCommand.predicate);
         }
 
         return false;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -48,36 +48,50 @@ public class DeleteCommand extends Command {
         requireNonNull(model);
 
         if (this.targetIndex != null) {
-            List<Person> lastShownList = model.getFilteredPersonList();
-            if (lastShownList.isEmpty()) {
-                throw new CommandException(DELETE_EMPTY_LIST_ERROR_MESSAGE);
-            }
-
-            if (targetIndex.getZeroBased() >= lastShownList.size()) {
-                throw new CommandException(String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
-                        lastShownList.size()));
-            }
-
-            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-            model.deletePerson(personToDelete);
+            Person personToDelete = deleteWithIndex(model);
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
 
         } else {
-            NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
-                    Arrays.asList(this.targetKeyword));
-            model.updateFilteredPersonList(predicate);
-            List<Person> filteredList = model.getFilteredPersonList();
+            Person personToDelete = deleteWithKeyword(model);
 
-            if (filteredList.isEmpty()) {
-                throw new CommandException(DELETE_EMPTY_LIST_ERROR_MESSAGE);
-            } else if (filteredList.size() == 1) {
-                Person personToDelete = filteredList.get(0);
-                model.deletePerson(personToDelete);
+            if (personToDelete != null) {
                 return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
             } else {
-                return new CommandResult(
-                        String.format(MESSAGE_DUPLICATE_HANDLING));
+                return new CommandResult(String.format(MESSAGE_DUPLICATE_HANDLING));
             }
+        }
+    }
+
+    public Person deleteWithIndex(Model model) throws CommandException {
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (lastShownList.isEmpty()) {
+            throw new CommandException(DELETE_EMPTY_LIST_ERROR_MESSAGE);
+        }
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                    lastShownList.size()));
+        }
+
+        Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deletePerson(personToDelete);
+        return personToDelete;
+    }
+
+    public Person deleteWithKeyword(Model model) throws CommandException {
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+                Arrays.asList(this.targetKeyword));
+        model.updateFilteredPersonList(predicate);
+        List<Person> filteredList = model.getFilteredPersonList();
+
+        if (filteredList.isEmpty()) {
+            throw new CommandException(DELETE_EMPTY_LIST_ERROR_MESSAGE);
+        } else if (filteredList.size() == 1) {
+            Person personToDelete = filteredList.get(0);
+            model.deletePerson(personToDelete);
+            return personToDelete;
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -123,21 +123,30 @@ public class DeleteCommand extends Command {
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
 
-        if (targetIndex == null && otherDeleteCommand.targetIndex == null
-                && predicate == null && otherDeleteCommand.predicate == null) {
+        // Both commands have null fields
+        boolean bothHaveNullIndex = targetIndex == null && otherDeleteCommand.targetIndex == null;
+        boolean bothHaveNullPredicates = predicate == null && otherDeleteCommand.predicate == null;
+
+        // Both commands have non-null fields
+        boolean bothHaveIndex = targetIndex != null && otherDeleteCommand.targetIndex != null;
+        boolean bothHavePredicates = predicate != null && otherDeleteCommand.predicate != null;
+
+        // Case 1: Both have null targetIndex and null predicate
+        if (bothHaveNullIndex && bothHaveNullPredicates) {
             return true;
         }
 
-        if (targetIndex != null && otherDeleteCommand.targetIndex != null
-                && predicate == null && otherDeleteCommand.predicate == null) {
+        // Case 2: Both have targetIndex but null predicate
+        if (bothHaveIndex && bothHaveNullPredicates) {
             return targetIndex.equals(otherDeleteCommand.targetIndex);
         }
 
-        if (targetIndex == null && otherDeleteCommand.targetIndex == null
-                && predicate != null && otherDeleteCommand.predicate != null) {
+        // Case 3: Both have null targetIndex but have predicate
+        if (bothHaveNullIndex && bothHavePredicates) {
             return predicate.equals(otherDeleteCommand.predicate);
         }
 
+        // All other cases are false
         return false;
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -25,7 +25,7 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) or KEYWORD (the name of contact)\n"
             + "Example: " + COMMAND_WORD + " 1" + "or " + COMMAND_WORD + " alex";
 
-    public static final String DELETE_EMPTY_LIST_ERROR_MESSAGE = "There is nothing to delete";
+    public static final String DELETE_EMPTY_LIST_ERROR_MESSAGE = "There is nothing to delete.";
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DUPLICATE_HANDLING =
             "Please specify the index of the contact you want to delete.\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -11,12 +11,11 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.NameMatchesNamePredicate;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes a person identified using it's displayed index from the address book.
+ * Deletes a person identified from the address book, using index or keyword.
  */
 public class DeleteCommand extends Command {
 
@@ -64,6 +63,13 @@ public class DeleteCommand extends Command {
         }
     }
 
+    /**
+     * Performs delete command logic when the input is an index.
+     *
+     * @param model {@code Model} which the command should operate on
+     * @return the person deleted
+     * @throws CommandException if an invalid index is given
+     */
     public Person deleteWithIndex(Model model) throws CommandException {
         List<Person> lastShownList = model.getFilteredPersonList();
         if (lastShownList.isEmpty()) {
@@ -81,6 +87,13 @@ public class DeleteCommand extends Command {
         return personToDelete;
     }
 
+    /**
+     * Performs delete command logic when the input is a {@code String}.
+     *
+     * @param model {@code Model} which the command should operate on
+     * @return the person deleted
+     * @throws CommandException if the list filtered using {@code targetKeyword} is empty
+     */
     public Person deleteWithKeyword(Model model) throws CommandException {
         NameMatchesNamePredicate predicate = new NameMatchesNamePredicate(
                 Arrays.asList(this.targetKeyword));

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameMatchesNamePredicate;
+import seedu.address.model.person.NameMatchesKeywordPredicate;
 
 /**
  * View the person in address book whose name matches the keyword.
@@ -20,9 +20,9 @@ public class ViewCommand extends Command {
             + "Parameters: NAME\n"
             + "Example: " + COMMAND_WORD + " alice";
 
-    private final NameMatchesNamePredicate predicate;
+    private final NameMatchesKeywordPredicate predicate;
 
-    public ViewCommand(NameMatchesNamePredicate predicate) {
+    public ViewCommand(NameMatchesKeywordPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -5,6 +5,9 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameMatchesKeywordPredicate;
+
+import java.util.Arrays;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -29,7 +32,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                 Index index = ParserUtil.parseIndex(trimmedArgs);
                 return new DeleteCommand(index, null);
             } else {
-                return new DeleteCommand(null, trimmedArgs);
+                String[] nameKeywords = trimmedArgs.split("\\s+");
+                NameMatchesKeywordPredicate predicate = new NameMatchesKeywordPredicate(
+                        Arrays.asList(nameKeywords));
+
+                return new DeleteCommand(null, predicate);
             }
         } catch (ParseException pe) {
             throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -18,12 +18,27 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            String trimmedArgs = args.trim();
+
+            if (trimmedArgs.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+
+            if (isNumeric(trimmedArgs)) {
+                Index index = ParserUtil.parseIndex(trimmedArgs);
+                return new DeleteCommand(index, null);
+            } else {
+                return new DeleteCommand(null, trimmedArgs);
+            }
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
+    }
+
+    private boolean isNumeric(String str) {
+        return str != null && str.matches("-?\\d+");
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,12 +2,13 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Arrays;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameMatchesKeywordPredicate;
 
-import java.util.Arrays;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameMatchesNamePredicate;
+import seedu.address.model.person.NameMatchesKeywordPredicate;
 
 /**
  * Parses input arguments and creates a new ViewCommand object
@@ -25,10 +25,9 @@ public class ViewCommandParser implements Parser<ViewCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
 
-        String[] splitKeywords = trimmedArgs.split("\\s+");
-        String[] nameKeywords = {String.join(" ", splitKeywords)};
+        String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new ViewCommand(new NameMatchesNamePredicate(Arrays.asList(nameKeywords)));
+        return new ViewCommand(new NameMatchesKeywordPredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/NameMatchesKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameMatchesKeywordPredicate.java
@@ -9,23 +9,17 @@ import seedu.address.commons.util.ToStringBuilder;
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
-public class NameMatchesNamePredicate implements Predicate<Person> {
+public class NameMatchesKeywordPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
-    public NameMatchesNamePredicate(List<String> names) {
+    public NameMatchesKeywordPredicate(List<String> names) {
         this.keywords = names;
     }
 
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(name -> {
-                    if (name.contains(" ")) {
-                        return person.getName().fullName.equalsIgnoreCase(name);
-                    } else {
-                        return StringUtil.containsWordIgnoreCase(person.getName().fullName, name);
-                    }
-                });
+                .allMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override
@@ -35,12 +29,12 @@ public class NameMatchesNamePredicate implements Predicate<Person> {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof NameMatchesNamePredicate)) {
+        if (!(other instanceof NameMatchesKeywordPredicate)) {
             return false;
         }
 
-        NameMatchesNamePredicate otherNameMatchesNamePredicate = (NameMatchesNamePredicate) other;
-        return keywords.equals(otherNameMatchesNamePredicate.keywords);
+        NameMatchesKeywordPredicate otherNameMatchesKeywordPredicate = (NameMatchesKeywordPredicate) other;
+        return keywords.equals(otherNameMatchesKeywordPredicate.keywords);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameMatchesKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameMatchesKeywordPredicate.java
@@ -18,7 +18,7 @@ public class NameMatchesKeywordPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
+        return !keywords.isEmpty() && keywords.stream()
                 .allMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -62,7 +62,7 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
-        showNoPerson(expectedModel);
+        expectedModel.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -30,7 +30,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, null);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -44,7 +44,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, null);
 
         assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
                 model.getFilteredPersonList().size()));
@@ -55,7 +55,7 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, null);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -75,7 +75,7 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, null);
 
         assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
                 model.getFilteredPersonList().size()));
@@ -83,14 +83,14 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON, null);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON, null);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON, null);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -106,7 +106,7 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(targetIndex, null);
         String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
         assertEquals(expected, deleteCommand.toString());
     }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameMatchesNamePredicate;
+import seedu.address.model.person.NameMatchesKeywordPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -32,10 +32,10 @@ public class ViewCommandTest {
 
     @Test
     public void equals() {
-        NameMatchesNamePredicate firstPredicate =
-                new NameMatchesNamePredicate(Collections.singletonList("first"));
-        NameMatchesNamePredicate secondPredicate =
-                new NameMatchesNamePredicate(Collections.singletonList("second"));
+        NameMatchesKeywordPredicate firstPredicate =
+                new NameMatchesKeywordPredicate(Collections.singletonList("first"));
+        NameMatchesKeywordPredicate secondPredicate =
+                new NameMatchesKeywordPredicate(Collections.singletonList("second"));
 
         ViewCommand viewFirstCommand = new ViewCommand(firstPredicate);
         ViewCommand viewSecondCommand = new ViewCommand(secondPredicate);
@@ -60,7 +60,7 @@ public class ViewCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameMatchesNamePredicate predicate = preparePredicate(" ");
+        NameMatchesKeywordPredicate predicate = preparePredicate(" ");
         ViewCommand command = new ViewCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -70,7 +70,7 @@ public class ViewCommandTest {
     @Test
     public void execute_multipleWordsInKeyword_exactNameMatched() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameMatchesNamePredicate predicate = preparePredicate("Kurz Elle Kunz");
+        NameMatchesKeywordPredicate predicate = preparePredicate("Kurz Elle Kunz");
         ViewCommand command = new ViewCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -80,7 +80,7 @@ public class ViewCommandTest {
     @Test
     public void execute_singleWordInKeyword_partialNameMatched() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        NameMatchesNamePredicate predicate = preparePredicate(KEYWORD_MATCHING_MEIER);
+        NameMatchesKeywordPredicate predicate = preparePredicate(KEYWORD_MATCHING_MEIER);
         ViewCommand command = new ViewCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -89,7 +89,7 @@ public class ViewCommandTest {
 
     @Test
     public void toStringMethod() {
-        NameMatchesNamePredicate predicate = new NameMatchesNamePredicate(Arrays.asList("keyword"));
+        NameMatchesKeywordPredicate predicate = new NameMatchesKeywordPredicate(Arrays.asList("keyword"));
         ViewCommand viewCommand = new ViewCommand(predicate);
         String expected = ViewCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, viewCommand.toString());
@@ -98,7 +98,7 @@ public class ViewCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameMatchesNamePredicate preparePredicate(String userInput) {
-        return new NameMatchesNamePredicate(Arrays.asList(userInput.split("\\s+")));
+    private NameMatchesKeywordPredicate preparePredicate(String userInput) {
+        return new NameMatchesKeywordPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -7,11 +7,10 @@ import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.CARLDUH;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
-import static seedu.address.testutil.TypicalPersons.ELLE;
-import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getAdditionalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,8 +26,8 @@ import seedu.address.model.person.NameMatchesKeywordPredicate;
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class ViewCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getAdditionalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getAdditionalAddressBook(), new UserPrefs());
 
     @Test
     public void equals() {
@@ -68,16 +67,6 @@ public class ViewCommandTest {
     }
 
     @Test
-    public void execute_multipleWordsInKeyword_exactNameMatched() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameMatchesKeywordPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        ViewCommand command = new ViewCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
-    }
-
-    @Test
     public void execute_singleWordInKeyword_partialNameMatched() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
         NameMatchesKeywordPredicate predicate = preparePredicate(KEYWORD_MATCHING_MEIER);
@@ -85,6 +74,23 @@ public class ViewCommandTest {
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleWordsInKeyword_nameMatched() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        NameMatchesKeywordPredicate predicate = preparePredicate("Carl Kurz");
+        ViewCommand command = new ViewCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, CARLDUH), model.getFilteredPersonList());
+
+        expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        predicate = preparePredicate("Carl Duh Kurz");
+        command = new ViewCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARLDUH), model.getFilteredPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -50,9 +50,16 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_delete() throws Exception {
+        // delete INDEX
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON, null), command);
+
+        // delete KEYWORD
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        command = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new DeleteCommand(null, new NameMatchesKeywordPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -25,7 +25,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.NameMatchesNamePredicate;
+import seedu.address.model.person.NameMatchesKeywordPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -83,7 +83,7 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo bar baz");
         ViewCommand command = (ViewCommand) parser.parseCommand(
                 ViewCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining("")));
-        assertEquals(new ViewCommand(new NameMatchesNamePredicate(keywords)), command);
+        assertEquals(new ViewCommand(new NameMatchesKeywordPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -80,9 +80,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_view() throws Exception {
-        List<String> keywords = Arrays.asList("foo bar baz");
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
         ViewCommand command = (ViewCommand) parser.parseCommand(
-                ViewCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining("")));
+                ViewCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new ViewCommand(new NameMatchesKeywordPredicate(keywords)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -52,7 +52,7 @@ public class AddressBookParserTest {
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON, null), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -5,9 +5,12 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.NameMatchesKeywordPredicate;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -23,6 +26,14 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON, null));
+
+        DeleteCommand expectedDeleteCommand =
+                new DeleteCommand(null, new NameMatchesKeywordPredicate(Arrays.asList("Alice", "Bob")));
+        assertParseSuccess(parser, "Alice Bob", expectedDeleteCommand);
+
+        assertParseSuccess(parser, " \n Alice Bob  \t", expectedDeleteCommand);
+
+        assertParseSuccess(parser, " \n Alice       Bob  \t", expectedDeleteCommand);
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -22,11 +22,18 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON, null));
     }
+
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "  ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -24,7 +24,7 @@ public class ViewCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         ViewCommand expectedFindCommand =
-                new ViewCommand(new NameMatchesKeywordPredicate(Arrays.asList("Alice Bob")));
+                new ViewCommand(new NameMatchesKeywordPredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         assertParseSuccess(parser, " \n Alice Bob  \t", expectedFindCommand);

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.ViewCommand;
-import seedu.address.model.person.NameMatchesNamePredicate;
+import seedu.address.model.person.NameMatchesKeywordPredicate;
 
 public class ViewCommandParserTest {
 
@@ -24,7 +24,7 @@ public class ViewCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         ViewCommand expectedFindCommand =
-                new ViewCommand(new NameMatchesNamePredicate(Arrays.asList("Alice Bob")));
+                new ViewCommand(new NameMatchesKeywordPredicate(Arrays.asList("Alice Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         assertParseSuccess(parser, " \n Alice Bob  \t", expectedFindCommand);

--- a/src/test/java/seedu/address/model/person/NameMatchesKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameMatchesKeywordPredicateTest.java
@@ -12,21 +12,21 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
 
-public class NameMatchesNamePredicateTest {
+public class NameMatchesKeywordPredicateTest {
 
     @Test
     public void equals() {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first second");
 
-        NameMatchesNamePredicate firstPredicate = new NameMatchesNamePredicate(firstPredicateKeywordList);
-        NameMatchesNamePredicate secondPredicate = new NameMatchesNamePredicate(secondPredicateKeywordList);
+        NameMatchesKeywordPredicate firstPredicate = new NameMatchesKeywordPredicate(firstPredicateKeywordList);
+        NameMatchesKeywordPredicate secondPredicate = new NameMatchesKeywordPredicate(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        NameMatchesNamePredicate firstPredicateCopy = new NameMatchesNamePredicate(firstPredicateKeywordList);
+        NameMatchesKeywordPredicate firstPredicateCopy = new NameMatchesKeywordPredicate(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -42,40 +42,40 @@ public class NameMatchesNamePredicateTest {
     @Test
     public void test_nameMatchesName_returnsTrue() {
         // Name with one word, partial name keyword
-        NameMatchesNamePredicate predicate = new NameMatchesNamePredicate(Collections.singletonList("Alice"));
+        NameMatchesKeywordPredicate predicate = new NameMatchesKeywordPredicate(Collections.singletonList("Alice"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        predicate = new NameMatchesNamePredicate(Collections.singletonList("Alice"));
+        predicate = new NameMatchesKeywordPredicate(Collections.singletonList("Alice"));
         assertTrue(predicate.test(new PersonBuilder().withName("Bob Alice").build()));
 
         // Name with multiple words, exact name keyword
-        predicate = new NameMatchesNamePredicate(Arrays.asList("Alice Bob"));
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Alice Bob"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        predicate = new NameMatchesNamePredicate(Arrays.asList("Alice Bob Carol"));
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Alice Bob Carol"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob Carol").build()));
 
         // Mixed-case keywords
-        predicate = new NameMatchesNamePredicate(Arrays.asList("aLIce bOB"));
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("aLIce bOB"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotMatchKeywords_returnsFalse() {
         // Zero keywords
-        NameMatchesNamePredicate predicate = new NameMatchesNamePredicate(Collections.emptyList());
+        NameMatchesKeywordPredicate predicate = new NameMatchesKeywordPredicate(Collections.emptyList());
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
 
         // Non-matching keyword
-        predicate = new NameMatchesNamePredicate(Arrays.asList("Carol"));
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Carol"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Non-exact name keyword
-        predicate = new NameMatchesNamePredicate(Arrays.asList("Alice Bob"));
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Alice Bob"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob Carol").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameMatchesNamePredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
@@ -83,9 +83,9 @@ public class NameMatchesNamePredicateTest {
     @Test
     public void toStringMethod() {
         List<String> keywords = List.of("keyword1", "keyword2");
-        NameMatchesNamePredicate predicate = new NameMatchesNamePredicate(keywords);
+        NameMatchesKeywordPredicate predicate = new NameMatchesKeywordPredicate(keywords);
 
-        String expected = NameMatchesNamePredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        String expected = NameMatchesKeywordPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
         assertEquals(expected, predicate.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/NameMatchesKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameMatchesKeywordPredicateTest.java
@@ -48,15 +48,15 @@ public class NameMatchesKeywordPredicateTest {
         predicate = new NameMatchesKeywordPredicate(Collections.singletonList("Alice"));
         assertTrue(predicate.test(new PersonBuilder().withName("Bob Alice").build()));
 
-        // Name with multiple words, exact name keyword
-        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Alice Bob"));
+        // Name with multiple words
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Alice Bob Carol"));
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob Carol").build()));
 
         // Mixed-case keywords
-        predicate = new NameMatchesKeywordPredicate(Arrays.asList("aLIce bOB"));
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
@@ -70,13 +70,9 @@ public class NameMatchesKeywordPredicateTest {
         predicate = new NameMatchesKeywordPredicate(Arrays.asList("Carol"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        // Non-exact name keyword
-        predicate = new NameMatchesKeywordPredicate(Arrays.asList("Alice Bob"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob Carol").build()));
-
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameMatchesKeywordPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+        predicate = new NameMatchesKeywordPredicate(Arrays.asList("9179", "alice@email.com", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("92839179")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -57,6 +57,10 @@ public class TypicalPersons {
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("84821311")
             .withEmail("hans@example.com").withAddress("chicago ave").build();
 
+    public static final Person CARLDUH = new PersonBuilder().withName("Carl Duh Kurz").withPhone("95352563")
+            .withEmail("heinz@example.com").withAddress("wall street")
+            .withTags("colleague").build();
+
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
@@ -81,5 +85,20 @@ public class TypicalPersons {
 
     public static List<Person> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical persons and an additional person.
+     */
+    public static AddressBook getAdditionalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Person person : getAdditionalPersons()) {
+            ab.addPerson(person);
+        }
+        return ab;
+    }
+
+    public static List<Person> getAdditionalPersons() {
+        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, CARLDUH, DANIEL, ELLE, FIONA, GEORGE));
     }
 }


### PR DESCRIPTION
  `delete INDEX` will directly delete the contact of that corresponding index

`delete KEYWORD`:

- If `KEYWORD `is a full name or partial name that is unique to that contact, the contact will be deleted directly.
- If `KEYWORD `is not unique to any contact, a list of contacts that is filtered using `KEYWORD `will be given to the user, allowing them to see the index of each contact in the filtered list. From there, the user needs to give a `delete INDEX` command to specify which of the contacts they want to delete.